### PR TITLE
Add detection of overflow error checks

### DIFF
--- a/include/bigfloat.h
+++ b/include/bigfloat.h
@@ -2,6 +2,8 @@
 #define BIG_FLOAT_H
 
 #define BIGFLOAT_PRECISION 512
+#define BIGFLOAT_SUCCESS 0
+#define BIGFLOAT_FAILURE 1
 
 typedef struct bigfloat
 {
@@ -19,11 +21,11 @@ enum BigFloatToString
 BigFloat *BigFloatCreate(char *);
 BigFloat *BigFloatCreateFromInt(int);
 void BigFloatFree(BigFloat *);
-void BigFloatParseString(BigFloat *, char *);
+char BigFloatParseString(BigFloat *, char *);
 char *BigFloatToString(BigFloat *, unsigned char);
-void BigFloatAdd(BigFloat *, BigFloat *, BigFloat *);
-void BigFloatSubtract(BigFloat *, BigFloat *, BigFloat *);
-void BigFloatMultiply(BigFloat *, BigFloat *, BigFloat *);
+char BigFloatAdd(BigFloat *, BigFloat *, BigFloat *);
+char BigFloatSubtract(BigFloat *, BigFloat *, BigFloat *);
+char BigFloatMultiply(BigFloat *, BigFloat *, BigFloat *);
 char BigFloatDivide(BigFloat *, BigFloat *, BigFloat *);
 char BigFloatModulo(BigFloat *, BigFloat *, BigFloat *);
 char BigFloatEquals(BigFloat *, BigFloat *);

--- a/include/bigfloat.h
+++ b/include/bigfloat.h
@@ -1,14 +1,18 @@
 #ifndef BIG_FLOAT_H
 #define BIG_FLOAT_H
 
-#define BIGFLOAT_PRECISION 512
+#define BIGFLOAT_PRECISION 256
+#define BIGFLOAT_DECIMAL_LIMITATION (BIGFLOAT_PRECISION / 3)
 #define BIGFLOAT_SUCCESS 0
 #define BIGFLOAT_FAILURE 1
+
+// Performs devision by using multiplication
+#define BIGFLOAT_USE_QUICK_DIVIDE 0
 
 typedef struct bigfloat
 {
 	unsigned char digits[BIGFLOAT_PRECISION];
-	short decimal;
+	unsigned short decimal;
 	unsigned char negative;
 } BigFloat;
 
@@ -40,6 +44,7 @@ void BigFloatIntConvert(BigFloat *);
 void BigFloatTrailingZeros(BigFloat *);
 void BigFloatShiftDownBy(char *, int, int);
 void BigFloatShiftUpBy(char *, int, int);
+void BigFloatDecimalLimiter(BigFloat *, int);
 int BigFloatToInt(BigFloat *);
 
 #endif


### PR DESCRIPTION
Added checks to each operation that performs a mathematical operation to a `BigFloat`; which results in the returning of `BIGFLOAT_FAILURE` if an overflow/underflow occurs, and returns `BIGFLOAT_SUCCESS` upon a successful operation.
Additionally, quick division was implemented, which - when enabled - uses multiplication to calculate the bulk of the divisible result; further speeding up execution times, however, this is not as accurate, so it is only enabled when compiled with `BIGFLOAT_USE_QUICK_DIVIDE` set to `1`.